### PR TITLE
fix crash from default.chest.register_chest

### DIFF
--- a/mods/default/chests.lua
+++ b/mods/default/chests.lua
@@ -297,9 +297,10 @@ function default.chest.register_chest(prefixed_name, d)
 	end
 
 	-- close opened chests on load
+	local modname, chestname = prefixed_name:match("^(:?.-):(.*)$")
 	minetest.register_lbm({
 		label = "close opened chests on load",
-		name = "default:close_" .. prefixed_name:gsub(":", "_") .. "_open",
+		name = modname .. ":close_" .. chestname .. "_open",
 		nodenames = {prefixed_name .. "_open"},
 		run_at_every_load = true,
 		action = function(pos, node)


### PR DESCRIPTION
If I try to register a chest using `default.chest.register_chest` from another mod, I get a crash.
```
/usr/share/minetest/builtin/game/register.lua:68: Name default:close_mymod_mychest_open does not follow naming conventions: "mymod:" or ":" prefix required
```
The reason is https://github.com/minetest/minetest_game/blob/16c663f87e63af6f799e2e8f9f8294c633e5786a/mods/default/chests.lua#L302 always uses the default namespace to register the lbm, even if called from another mod.

This is the fix I used to continue. Feel free to reject if there is a better/cleaner way.